### PR TITLE
JCN-149-parametro-database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- table name (index) can be obtained from the `database` setting in config
 
 ## [1.0.2] - 2019-08-29
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Constructs the Elasticsearch driver instance, connected with the `config [Object
 - user `[String]`: Elasticsearch user for the host.  
 - password `[String]`: Elasticsearch password for the host.  
 - limit `[Number]`: Default limit for getting operations.  
+- database `[String]`: Elasticsearch index name. **This config replaces the model table name (if exists)**.  
 - awsCredentials `[Boolean]`: Set to `true` if you need to use AWS credentials ENV variables for the host connection/authentication.  
 
 **Config usage:**  
@@ -32,6 +33,7 @@ Constructs the Elasticsearch driver instance, connected with the `config [Object
 	user: 'Username', // Default empty
 	password: 'password', // Default empty
 	limit: 10, // Default 500
+	database: 'my_data', // Default empty / model table
 	awsCredentials: true // Default false
 }
 ```

--- a/lib/elasticsearch.js
+++ b/lib/elasticsearch.js
@@ -37,6 +37,7 @@ class ElasticSearch {
 			user: config.user || '',
 			password: config.password || '',
 			limit: config.limit || DEFAULT_LIMIT,
+			database: config.database || '',
 			awsCredentials: config.awsCredentials || false
 		};
 
@@ -109,7 +110,7 @@ class ElasticSearch {
 		if(!model)
 			throw new ElasticSearchError('Empty model', ElasticSearchError.codes.INVALID_MODEL);
 
-		if(!model.constructor.table)
+		if(!model.constructor.table && !this.config.database)
 			throw new ElasticSearchError('Invalid model', ElasticSearchError.codes.INVALID_MODEL);
 
 		if(model.constructor.sortableFields && (typeof model.constructor.sortableFields !== 'object' || Array.isArray(model.constructor.sortableFields))) {
@@ -122,10 +123,10 @@ class ElasticSearch {
 	/**
 	 * Get the index name converted into snake_case
 	 * @param {Model} model Model instance
-	 * @returns {String} Index/table name from the model, converted into snake_case
+	 * @returns {String} Index/table name from the model or config, converted into snake_case
 	 */
 	_getIndex(model) {
-		return convertToSnakeCase(model.constructor.table);
+		return convertToSnakeCase(this.config.database || model.constructor.table);
 	}
 
 	/**

--- a/tests/elasticsearch-test.js
+++ b/tests/elasticsearch-test.js
@@ -209,6 +209,33 @@ describe('ElasticSearch', () => {
 
 			elastic._validateModel(new OtherModel());
 		});
+
+		it('should not throw invalid model when the table not exists in model but the database settings exists', () => {
+
+			elastic.config.database = 'myNewTable';
+
+			assert.doesNotThrow(() => elastic._validateModel({}));
+
+			elastic.config.database = '';
+		});
+	});
+
+	describe('_getIndex', () => {
+
+		it('should return the model index name converted into snake_case', () => {
+
+			assert.deepStrictEqual(elastic._getIndex(model), 'my_table');
+
+		});
+
+		it('should return the database setting converted into snake_case instead of model table name when the setting exists', async () => {
+
+			elastic.config.database = 'myNewTable';
+
+			assert.deepStrictEqual(elastic._getIndex(model), 'my_new_table');
+
+			elastic.config.database = '';
+		});
 	});
 
 	describe('buildIndex()', () => {


### PR DESCRIPTION
**JCN-149-PARAMETRO-DATABASE**
JCN-149 Obtener nombre de tabla desde parámetro database

**LINK AL TICKET**
https://fizzmod.atlassian.net/browse/JCN-149

**DESCRIPCIÓN DEL REQUERIMIENTO**
2.1 El paquete debe tomar la propiedad `database` en la config y utilizarla como nombre de tabla (indice) en lugar de la del modelo (en caso de existir)

**DESCRIPCIÓN DE LA SOLUCIÓN**
Se realizaron los desarrollos solicitados