### PR TITLE
JCN-157-prefix-para-tablas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `prefix` support for table names
 
 ## [1.0.2] - 2019-08-29
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Constructs the Elasticsearch driver instance, connected with the `config [Object
 - user `[String]`: Elasticsearch user for the host.  
 - password `[String]`: Elasticsearch password for the host.  
 - limit `[Number]`: Default limit for getting operations.  
+- prefix `[String]`: Prefix for table name, if is setted, any operation will use the model table name with the prefix. Ex: `table.prefix`.  
 - awsCredentials `[Boolean]`: Set to `true` if you need to use AWS credentials ENV variables for the host connection/authentication.  
 
 **Config usage:**  
@@ -32,6 +33,7 @@ Constructs the Elasticsearch driver instance, connected with the `config [Object
 	user: 'Username', // Default empty
 	password: 'password', // Default empty
 	limit: 10, // Default 500
+	prefix: 'products', // Default empty
 	awsCredentials: true // Default false
 }
 ```

--- a/lib/elasticsearch.js
+++ b/lib/elasticsearch.js
@@ -37,6 +37,7 @@ class ElasticSearch {
 			user: config.user || '',
 			password: config.password || '',
 			limit: config.limit || DEFAULT_LIMIT,
+			prefix: config.prefix || '',
 			awsCredentials: config.awsCredentials || false
 		};
 
@@ -120,12 +121,14 @@ class ElasticSearch {
 	}
 
 	/**
-	 * Get the index name converted into snake_case
+	 * Get the index name converted into snake_case is case of a prefix is setted it returns the index name with the prefix, concatenated with a dot.
 	 * @param {Model} model Model instance
 	 * @returns {String} Index/table name from the model, converted into snake_case
 	 */
 	_getIndex(model) {
-		return convertToSnakeCase(model.constructor.table);
+		return convertToSnakeCase(
+			this.config.prefix ? `${model.constructor.table}.${this.config.prefix}` : model.constructor.table
+		);
 	}
 
 	/**

--- a/tests/elasticsearch-test.js
+++ b/tests/elasticsearch-test.js
@@ -211,6 +211,26 @@ describe('ElasticSearch', () => {
 		});
 	});
 
+	describe('_getIndex()', () => {
+
+		it('should return the table name from the model converted into snake_case', () => {
+
+			assert.deepStrictEqual(elastic._getIndex(model), 'my_table');
+
+		});
+
+		it('should return the table name with the prefix when it\'s setted in config', () => {
+
+			elastic.config.prefix = 'prefix';
+
+			assert.deepStrictEqual(elastic._getIndex(model), 'my_table.prefix');
+
+			delete elastic.config.prefix;
+
+		});
+
+	});
+
 	describe('buildIndex()', () => {
 
 		it('should create an index (if not exists) and put the mappings parsed from the model into it', async () => {


### PR DESCRIPTION
**JCN-157-PREFIX-PARA-TABLAS**
JCN-157 Utilizar prefix opcional para las tablas

**LINK AL TICKET**
https://fizzmod.atlassian.net/browse/JCN-157

**DESCRIPCIÓN DEL REQUERIMIENTO**
4.1. Se debe utilizar en caso de llegar un prefix para las tablas
4.2. El prefix se concatenará siempre que se utilice una tabla
4.3. Se deberá utilizar un punto `.` para contacternar prefix y tabla.

**DESCRIPCIÓN DE LA SOLUCIÓN**
Se realizaron los requerimientos solicitados