### PR TITLE
[QUICK] JCN-fix-filtros-tipo-de-datos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- `ElasticSearchFilters` field datatypes will be filtered by `raw` only when exists in the model `sortableFields` otherwise will use `keyword` instead.
+
 ## [1.1.0] - 2019-09-12
 ### Added
 - `ElasticSearchConfigError`

--- a/lib/elasticsearch-filters.js
+++ b/lib/elasticsearch-filters.js
@@ -8,15 +8,38 @@ const ElasticSearchError = require('./elasticsearch-error');
  */
 class ElasticSearchFilters {
 
+	static get model() {
+		return this._model;
+	}
+
+	static set model(model) {
+		this._model = model;
+	}
+
+	/**
+	 * Search the received field into the model and returns the respective ES fieldType
+	 * @param {String} field the field name
+	 * @returns {String} ES fieldType
+	 */
+	static _getFieldType(field) {
+
+		if(this.model.constructor.sortableFields[field])
+			return 'raw';
+
+		return 'keyword';
+	}
+
 	/**
 	 * Get the elasticsearch filters query from the received filters
 	 * @param {Object} filters filters
 	 * @returns {Object} elasticsearch filters
 	 */
-	static getFilters(filters) {
+	static getFilters(model, filters) {
 
 		if(!filters || typeof filters !== 'object' || Array.isArray(filters))
 			throw new ElasticSearchError('Invalid filters', ElasticSearchError.codes.INVALID_FILTERS);
+
+		this.model = model;
 
 		filters = this._prepareFilters(filters);
 
@@ -70,8 +93,8 @@ class ElasticSearchFilters {
 	static _formatByOperator(parsedFilters, operator, fields) {
 
 		const operators = {
-			eq: this._formatEq,
-			ne: this._formatNe,
+			eq: this._formatEq.bind(this),
+			ne: this._formatNe.bind(this),
 			in: this._formatIn,
 			nin: this._formatNin,
 			gt: this._formatGt,
@@ -99,7 +122,7 @@ class ElasticSearchFilters {
 
 		parsedFilters.bool = parsedFilters.bool || {};
 		parsedFilters.bool.must = parsedFilters.bool.must || [];
-		parsedFilters.bool.must.push({ term: { [`${field}.raw`]: value } });
+		parsedFilters.bool.must.push({ term: { [`${field}.${this._getFieldType(field)}`]: value } });
 	}
 
 	/**
@@ -112,7 +135,7 @@ class ElasticSearchFilters {
 
 		parsedFilters.bool = parsedFilters.bool || {};
 		parsedFilters.bool.must_not = parsedFilters.bool.must_not || [];
-		parsedFilters.bool.must_not.push({ term: { [`${field}.raw`]: value } });
+		parsedFilters.bool.must_not.push({ term: { [`${field}.${this._getFieldType(field)}`]: value } });
 	}
 
 	/**

--- a/lib/elasticsearch.js
+++ b/lib/elasticsearch.js
@@ -444,7 +444,7 @@ class ElasticSearch {
 
 		const limit = params.limit || this.config.limit;
 		const page = params.page || 1;
-		const filters = params.filters ? ElasticSearchFilters.getFilters(params.filters) : {};
+		const filters = params.filters ? ElasticSearchFilters.getFilters(model, params.filters) : {};
 		const order = params.order ? this._parseSortingParams(params.order) : {};
 
 		try {
@@ -526,7 +526,7 @@ class ElasticSearch {
 				refresh: true,
 				type: '_doc',
 				body: {
-					...ElasticSearchFilters.getFilters(filters),
+					...ElasticSearchFilters.getFilters(model, filters),
 					...this._parseValuesForUpdate(values)
 				}
 			});
@@ -614,7 +614,7 @@ class ElasticSearch {
 				type: '_doc',
 				refresh: true,
 				body: {
-					...ElasticSearchFilters.getFilters(filters)
+					...ElasticSearchFilters.getFilters(model, filters)
 				}
 			});
 


### PR DESCRIPTION
**[QUICK] JCN-FIX-FILTROS-TIPO-DE-DATOS**
Fix de los tipos de datos por campo en los filtros

**DESCRIPCIÓN DEL REQUERIMIENTO**
Solucionar el problema de usar el tipo de dato `raw` para los campos no colocados en los `sortableFields` del modelo y usar tipo `keyword` en su lugar

**DESCRIPCIÓN DE LA SOLUCIÓN**
Se desarrollaron los requerimientos solicitados