### PR TITLE
[QUICK] JCN-config-timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- `requestTimeout` and `maxRetries` support in config
+
 ## [1.2.1] - 2019-12-03
 ### Fixed
 - `distinct` will return all posible results instead 10

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Constructs the Elasticsearch driver instance, connected with the `config [Object
 - limit `[Number]`: Default limit for getting operations.  
 - prefix `[String]`: Prefix for table name, if it's setted, any operation will use the model table name with the prefix. Ex: `table.prefix`.  
 - awsCredentials `[Boolean]`: Set to `true` if you need to use AWS credentials ENV variables for the host connection/authentication.  
+- requestTimeout `[Number]`: The max timeout for operation in miliseconds, default 4000 (4s).  
+- maxRetries `[Number]`: The max retries for operation, default 3.
 
 **Config usage:**  
 ```js
@@ -34,7 +36,9 @@ Constructs the Elasticsearch driver instance, connected with the `config [Object
 	password: 'password', // Default empty
 	limit: 10, // Default 500
 	prefix: 'products', // Default empty
-	awsCredentials: true // Default false
+	awsCredentials: true, // Default false
+	requestTimeout: 2000, // Default 4000
+	maxRetries: 1 // Default 3
 }
 ```
 

--- a/lib/config-validator.js
+++ b/lib/config-validator.js
@@ -10,7 +10,9 @@ const ELASTICSEARCH_CONFIG_STRUCT = {
 	password: 'string',
 	limit: 'number',
 	prefix: 'string',
-	awsCredentials: 'boolean'
+	awsCredentials: 'boolean',
+	requestTimeout: 'number',
+	maxRetries: 'number'
 };
 
 /**

--- a/lib/elasticsearch.js
+++ b/lib/elasticsearch.js
@@ -16,6 +16,8 @@ const ElasticSearchError = require('./elasticsearch-error');
 const ConfigValidator = require('./config-validator');
 
 const DEFAULT_LIMIT = 500;
+const DEFAULT_TIMEOUT = 4000;
+const DEFAULT_RETRIES = 3;
 const ES_DEFAULT_HOST = 'http://localhost';
 const ES_MAX_BUCKET_SIZE = 2147483647;
 
@@ -41,7 +43,9 @@ class ElasticSearch {
 			password: config.password || '',
 			limit: config.limit || DEFAULT_LIMIT,
 			prefix: config.prefix || '',
-			awsCredentials: config.awsCredentials || false
+			awsCredentials: config.awsCredentials || false,
+			requestTimeout: config.requestTimeout || DEFAULT_TIMEOUT,
+			maxRetries: config.maxRetries || DEFAULT_RETRIES
 		};
 
 		try {
@@ -93,6 +97,8 @@ class ElasticSearch {
 			try {
 				this._client = new elasticsearch.Client({
 					host: `${this.config.protocol}${this._userPrefix}${this.config.host}${this.config.port ? `:${this.config.port}` : ''}`,
+					requestTimeout: this.config.requestTimeout,
+					maxRetries: this.config.maxRetries,
 					...this._awsCredentials
 				});
 			} catch(err) {


### PR DESCRIPTION
**[QUICK] JCN-CONFIG-TIMEOUT**
Agregar soporte para configurar el timeout y reintentos en las operaciones con elasticsearch

**DESCRIPCIÓN DE LA SOLUCIÓN**
Se desarrollaron los requerimientos solicitados